### PR TITLE
Mobile fix: real viewport height + invalidateSize + touch polish

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,6 @@
+
 @import 'leaflet/dist/leaflet.css';
 /* Global base styles */
+
+.station-pin svg { filter: drop-shadow(0 1px 2px rgba(0,0,0,.25)); }
 

--- a/app/model1-heatmap/Model1HeatmapClient.tsx
+++ b/app/model1-heatmap/Model1HeatmapClient.tsx
@@ -25,6 +25,17 @@ export default function Model1HeatmapClient() {
 
   useEffect(() => {
     ensureLeafletIconFix();
+    // Set real viewport height for mobile
+    const setVh = () => {
+      document.documentElement.style.setProperty('--vh', `${window.innerHeight * 0.01}px`);
+    };
+    setVh();
+    window.addEventListener('resize', setVh);
+    window.addEventListener('orientationchange', setVh);
+    return () => {
+      window.removeEventListener('resize', setVh);
+      window.removeEventListener('orientationchange', setVh);
+    };
   }, []);
 
   useEffect(() => {
@@ -63,7 +74,7 @@ export default function Model1HeatmapClient() {
   }
 
   return (
-    <div className="h-screen w-full flex flex-col">
+  <div className="h-screen w-full flex flex-col">
       <TopBar
         heatOn={heatOn}
         setHeatOn={setHeatOn}
@@ -77,7 +88,7 @@ export default function Model1HeatmapClient() {
         <span className="ml-4 text-xs bg-gray-200 px-2 py-1 rounded">Stations: {stations.length}</span>
         <span className="ml-2 text-xs bg-gray-100 px-2 py-1 rounded cursor-pointer" title="Debug" onClick={() => setToast(`Source: ${source}, Count: ${stations.length}, Coords: ${stations[0]?.lat},${stations[0]?.lng}`)}>?</span>
       </div>
-      <div className="flex-1 min-h-[75vh] relative">
+      <div className="flex-1 relative" style={{ minHeight: 'calc(var(--vh, 1vh) * 100 - 56px)' }}>
         <ClientMap
           stations={stations}
           bounds={bounds}

--- a/app/model1-heatmap/Model1HeatmapClient.tsx
+++ b/app/model1-heatmap/Model1HeatmapClient.tsx
@@ -5,6 +5,7 @@ import ToggleBar from '../../components/ui/ToggleBar';
 import Toast from '../../components/ui/Toast';
 import SearchControl from '../../components/Map/SearchControl';
 import { Station } from '../../lib/stations/types';
+import { ensureLeafletIconFix } from '@/lib/leafletIconFix';
 
 const COUNCIL_URL = '/data/councils-london.geo.json';
 const STATIONS_URL = '/api/stations';
@@ -16,6 +17,10 @@ export default function Model1HeatmapClient() {
   const [showCouncil, setShowCouncil] = useState(false);
   const [toast, setToast] = useState('');
   const [bounds, setBounds] = useState<[[number, number], [number, number]]>([[51.49, -0.15], [51.52, -0.07]]);
+
+  useEffect(() => {
+    ensureLeafletIconFix();
+  }, []);
 
   useEffect(() => {
     fetch(STATIONS_URL)
@@ -61,7 +66,7 @@ export default function Model1HeatmapClient() {
         <span className="ml-4 text-xs bg-gray-200 px-2 py-1 rounded">Stations: {stations.length}</span>
         <span className="ml-2 text-xs bg-gray-100 px-2 py-1 rounded cursor-pointer" title="Debug" onClick={() => setToast(`Source: ${source}, Count: ${stations.length}, Coords: ${stations[0]?.lat},${stations[0]?.lng}`)}>?</span>
       </div>
-      <div className="flex-1">
+      <div id="map-root" className="flex-1 min-h-[75vh] relative">
         <ClientMap
           stations={stations}
           bounds={bounds}

--- a/app/model1-heatmap/Model1HeatmapClient.tsx
+++ b/app/model1-heatmap/Model1HeatmapClient.tsx
@@ -17,6 +17,7 @@ export default function Model1HeatmapClient() {
   const [showCouncil, setShowCouncil] = useState(false);
   const [toast, setToast] = useState('');
   const [bounds, setBounds] = useState<[[number, number], [number, number]]>([[51.49, -0.15], [51.52, -0.07]]);
+  const [showHeat, setShowHeat] = useState(true);
 
   useEffect(() => {
     ensureLeafletIconFix();
@@ -66,12 +67,13 @@ export default function Model1HeatmapClient() {
         <span className="ml-4 text-xs bg-gray-200 px-2 py-1 rounded">Stations: {stations.length}</span>
         <span className="ml-2 text-xs bg-gray-100 px-2 py-1 rounded cursor-pointer" title="Debug" onClick={() => setToast(`Source: ${source}, Count: ${stations.length}, Coords: ${stations[0]?.lat},${stations[0]?.lng}`)}>?</span>
       </div>
-      <div id="map-root" className="flex-1 min-h-[75vh] relative">
+      <div className="flex-1 min-h-[75vh] relative">
         <ClientMap
           stations={stations}
           bounds={bounds}
           councilGeoJson={councilGeoJson}
           showCouncil={showCouncil}
+          showHeat={showHeat}
           onZoomToData={handleZoomToData}
         />
       </div>

--- a/app/model1-heatmap/Model1HeatmapClient.tsx
+++ b/app/model1-heatmap/Model1HeatmapClient.tsx
@@ -5,7 +5,7 @@ import TopBar from '../../components/ui/TopBar';
 import Toast from '../../components/ui/Toast';
 import SearchControl from '../../components/Map/SearchControl';
 import { Station } from '../../lib/stations/types';
-import { ensureLeafletIconFix } from '@/lib/leafletIconFix';
+import { ensureLeafletIconFix } from '../../lib/leafletIconFix';
 
 const COUNCIL_URL = '/data/councils-london.geo.json';
 const STATIONS_URL = '/api/stations';

--- a/app/model1-heatmap/Model1HeatmapClient.tsx
+++ b/app/model1-heatmap/Model1HeatmapClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from 'react';
 import ClientMap from '../../components/Map/ClientMap';
-import ToggleBar from '../../components/ui/ToggleBar';
+import TopBar from '../../components/ui/TopBar';
 import Toast from '../../components/ui/Toast';
 import SearchControl from '../../components/Map/SearchControl';
 import { Station } from '../../lib/stations/types';
@@ -17,7 +17,11 @@ export default function Model1HeatmapClient() {
   const [showCouncil, setShowCouncil] = useState(false);
   const [toast, setToast] = useState('');
   const [bounds, setBounds] = useState<[[number, number], [number, number]]>([[51.49, -0.15], [51.52, -0.07]]);
-  const [showHeat, setShowHeat] = useState(true);
+  const [heatOn, setHeatOn] = useState(true);
+  const [markersOn, setMarkersOn] = useState(true);
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const [feedbackMsg, setFeedbackMsg] = useState('');
+  const [feedbackLoading, setFeedbackLoading] = useState(false);
 
   useEffect(() => {
     ensureLeafletIconFix();
@@ -60,9 +64,15 @@ export default function Model1HeatmapClient() {
 
   return (
     <div className="h-screen w-full flex flex-col">
+      <TopBar
+        heatOn={heatOn}
+        setHeatOn={setHeatOn}
+        markersOn={markersOn}
+        setMarkersOn={setMarkersOn}
+        onFeedbackClick={() => setFeedbackOpen(true)}
+      />
       <div className="p-2 flex gap-2 items-center">
         <SearchControl onSearch={handleSearch} />
-        <ToggleBar toggles={[{ label: 'Council', value: 'council' }]} onToggle={handleToggleCouncil} active={showCouncil ? 'council' : ''} />
         <button className="px-3 py-1 bg-green-600 text-white rounded" onClick={handleZoomToData}>Zoom to data</button>
         <span className="ml-4 text-xs bg-gray-200 px-2 py-1 rounded">Stations: {stations.length}</span>
         <span className="ml-2 text-xs bg-gray-100 px-2 py-1 rounded cursor-pointer" title="Debug" onClick={() => setToast(`Source: ${source}, Count: ${stations.length}, Coords: ${stations[0]?.lat},${stations[0]?.lng}`)}>?</span>
@@ -73,10 +83,55 @@ export default function Model1HeatmapClient() {
           bounds={bounds}
           councilGeoJson={councilGeoJson}
           showCouncil={showCouncil}
-          showHeat={showHeat}
+          heatOn={heatOn}
+          markersOn={markersOn}
           onZoomToData={handleZoomToData}
         />
       </div>
+      {feedbackOpen && (
+        <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-md">
+            <h2 className="text-lg font-bold mb-2">Feedback</h2>
+            <textarea
+              className="w-full border rounded p-2 mb-3"
+              rows={3}
+              value={feedbackMsg}
+              onChange={e => setFeedbackMsg(e.target.value)}
+              placeholder="Your feedback..."
+              disabled={feedbackLoading}
+            />
+            <div className="flex gap-2 justify-end">
+              <button className="px-3 py-1 rounded bg-gray-200" onClick={() => setFeedbackOpen(false)} disabled={feedbackLoading}>Cancel</button>
+              <button
+                className="px-4 py-1 rounded bg-amber-500 text-white font-semibold"
+                disabled={feedbackLoading || !feedbackMsg.trim()}
+                onClick={async () => {
+                  setFeedbackLoading(true);
+                  try {
+                    const res = await fetch('/api/feedback', {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ stationId: 'ui', vote: 'good', message: feedbackMsg }),
+                    });
+                    const data = await res.json();
+                    if (data.ok) {
+                      setToast('Feedback sent!');
+                      setFeedbackOpen(false);
+                      setFeedbackMsg('');
+                    } else {
+                      setToast('Error sending feedback');
+                    }
+                  } catch {
+                    setToast('Error sending feedback');
+                  } finally {
+                    setFeedbackLoading(false);
+                  }
+                }}
+              >Send</button>
+            </div>
+          </div>
+        </div>
+      )}
       <Toast message={toast} show={!!toast} onClose={() => setToast('')} />
     </div>
   );

--- a/components/Map/ClientMap.tsx
+++ b/components/Map/ClientMap.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { MapContainer, TileLayer, Pane, Marker, Popup, ZoomControl, GeoJSON } from 'react-leaflet';
 import { Station } from '../../lib/stations/types';
 import HeatLayer from './HeatLayer';
-import { createStationDivIcon } from '@/lib/icons/stationDivIcon';
+import { createStationDivIcon } from '../../lib/icons/stationDivIcon';
 
 export default function ClientMap({ stations, bounds, councilGeoJson, showCouncil, heatOn, markersOn, onZoomToData }: {
   stations: Station[];

--- a/components/Map/ClientMap.tsx
+++ b/components/Map/ClientMap.tsx
@@ -4,11 +4,12 @@ import { MapContainer, TileLayer, Pane, Marker, ZoomControl, GeoJSON } from 'rea
 import { Station } from '../../lib/stations/types';
 import HeatLayer from './HeatLayer';
 
-export default function ClientMap({ stations, bounds, councilGeoJson, showCouncil, onZoomToData }: {
+export default function ClientMap({ stations, bounds, councilGeoJson, showCouncil, showHeat, onZoomToData }: {
   stations: Station[];
   bounds: [[number, number], [number, number]];
   councilGeoJson?: any;
   showCouncil: boolean;
+  showHeat?: boolean;
   onZoomToData: () => void;
 }) {
   const [map, setMap] = useState<any>(null);
@@ -38,14 +39,16 @@ export default function ClientMap({ stations, bounds, councilGeoJson, showCounci
     >
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" attribution="&copy; OpenStreetMap contributors" />
       <ZoomControl position="topright" />
-      <Pane name="markers" style={{ zIndex: 650 }}>
+      <Pane name="stations" style={{ zIndex: 650 }}>
         {stations.map(s => (
           <Marker key={s.id} position={[s.lat, s.lng]} />
         ))}
       </Pane>
-      <Pane name="heat" style={{ zIndex: 600 }}>
-        <HeatLayer points={stations.map(s => [s.lat, s.lng, 0.7])} />
-      </Pane>
+      {showHeat && (
+        <Pane name="heat" style={{ zIndex: 600 }}>
+          <HeatLayer points={stations.map(s => [s.lat, s.lng, Math.max(0.3, Math.min(1, (typeof s.connectors === 'number' ? s.connectors : 1)/3))])} radius={30} blur={20} />
+        </Pane>
+      )}
       {showCouncil && councilGeoJson && (
         <Pane name="council" style={{ zIndex: 500 }}>
           <GeoJSON data={councilGeoJson} style={() => ({ weight: 1, color: '#3b82f6', fillOpacity: 0.08 })} />

--- a/components/Map/ClientMap.tsx
+++ b/components/Map/ClientMap.tsx
@@ -1,10 +1,8 @@
 "use client";
-import dynamic from 'next/dynamic';
 import { useRef, useEffect, useState } from 'react';
 import { MapContainer, TileLayer, Pane, Marker, ZoomControl, GeoJSON } from 'react-leaflet';
 import { Station } from '../../lib/stations/types';
 import HeatLayer from './HeatLayer';
-import { ensureLeafletIconFix } from '@/lib/leafletIconFix';
 
 export default function ClientMap({ stations, bounds, councilGeoJson, showCouncil, onZoomToData }: {
   stations: Station[];
@@ -13,24 +11,33 @@ export default function ClientMap({ stations, bounds, councilGeoJson, showCounci
   showCouncil: boolean;
   onZoomToData: () => void;
 }) {
-  const mapRef = useRef<any>(null);
-  useEffect(() => { ensureLeafletIconFix(); }, []);
+  const [map, setMap] = useState<any>(null);
   useEffect(() => {
-    if (mapRef.current && bounds) {
-      mapRef.current.fitBounds(bounds, { padding: [40, 40] });
+    if (!map) return;
+    const onReady = () => map.invalidateSize();
+    onReady();
+    const onResize = () => map.invalidateSize();
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [map]);
+  useEffect(() => {
+    if (map && bounds) {
+      map.fitBounds(bounds, { padding: [40, 40] });
     }
-  }, [bounds]);
+  }, [map, bounds]);
 
   return (
     <MapContainer
-      ref={mapRef}
-      style={{ height: '100%', width: '100%' }}
-      zoom={12}
-      center={[(bounds[0][0] + bounds[1][0]) / 2, (bounds[0][1] + bounds[1][1]) / 2]}
-      zoomControl={false}
+      className="h-full w-full"
+      style={{ height: '100%', width: '100%', minHeight: '75vh' }}
+      center={[51.515, -0.141]}
+      zoom={13}
+      scrollWheelZoom
+      preferCanvas
+      ref={node => { if (node) setMap(node); }}
     >
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" attribution="&copy; OpenStreetMap contributors" />
       <ZoomControl position="topright" />
-      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
       <Pane name="markers" style={{ zIndex: 650 }}>
         {stations.map(s => (
           <Marker key={s.id} position={[s.lat, s.lng]} />

--- a/components/ui/TopBar.tsx
+++ b/components/ui/TopBar.tsx
@@ -1,0 +1,30 @@
+// components/ui/TopBar.tsx
+'use client';
+export default function TopBar({
+  heatOn, setHeatOn, markersOn, setMarkersOn, onFeedbackClick,
+}: {
+  heatOn: boolean; setHeatOn: (v:boolean)=>void;
+  markersOn: boolean; setMarkersOn: (v:boolean)=>void;
+  onFeedbackClick: ()=>void;
+}) {
+  return (
+    <div className="w-full flex items-center justify-between gap-3 px-3 py-2 bg-white/90 backdrop-blur border-b">
+      <div className="flex items-center gap-4">
+        <label className="inline-flex items-center gap-2">
+          <input type="checkbox" checked={heatOn} onChange={e=>setHeatOn(e.target.checked)} />
+          <span>Heatmap</span>
+        </label>
+        <label className="inline-flex items-center gap-2">
+          <input type="checkbox" checked={markersOn} onChange={e=>setMarkersOn(e.target.checked)} />
+          <span>Markers</span>
+        </label>
+      </div>
+      <button
+        onClick={onFeedbackClick}
+        className="px-4 py-1.5 rounded-lg bg-amber-500 text-white font-medium shadow"
+      >
+        Feedback
+      </button>
+    </div>
+  );
+}

--- a/lib/hooks/useInvalidateOnResize.ts
+++ b/lib/hooks/useInvalidateOnResize.ts
@@ -1,0 +1,20 @@
+'use client';
+import { useEffect } from 'react';
+import type L from 'leaflet';
+export function useInvalidateOnResize(map: L.Map | null) {
+  useEffect(() => {
+    if (!map) return;
+    const invalidate = () => map.invalidateSize();
+    const t = setTimeout(invalidate, 50);      // after first paint
+    map.once('load', invalidate);
+    window.addEventListener('resize', invalidate);
+    window.addEventListener('orientationchange', invalidate);
+    document.addEventListener('visibilitychange', invalidate);
+    return () => {
+      clearTimeout(t);
+      window.removeEventListener('resize', invalidate);
+      window.removeEventListener('orientationchange', invalidate);
+      document.removeEventListener('visibilitychange', invalidate);
+    };
+  }, [map]);
+}

--- a/lib/icons/stationDivIcon.ts
+++ b/lib/icons/stationDivIcon.ts
@@ -1,0 +1,27 @@
+// lib/icons/stationDivIcon.ts
+'use client';
+import L from 'leaflet';
+
+export function createStationDivIcon(size = 28) {
+  const w = size, h = Math.round(size * 1.35);
+  const svg = `
+  <svg width="${w}" height="${h}" viewBox="0 0 32 44" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#3BA9FF"/>
+        <stop offset="100%" stop-color="#0A74FF"/>
+      </linearGradient>
+    </defs>
+    <path d="M16 0c8.3 0 15 6.7 15 15 0 10.5-12.4 19.6-14.4 28.2a1 1 0 0 1-1.2 0C13.4 34.6 1 25.5 1 15 1 6.7 7.7 0 16 0z" fill="url(#g)" stroke="#0B5ED7" stroke-width="1.2" />
+    <circle cx="16" cy="15" r="8.5" fill="white" />
+    <path d="M12.2 15h8v2.2c0 2.1-1.7 3.8-3.8 3.8h-0.4c-2.1 0-3.8-1.7-3.8-3.8V15zm1.1-4.6h1.6v3h-1.6v-3zm4.8 0h1.6v3h-1.6v-3z" fill="#0B5ED7"/>
+  </svg>`.trim();
+
+  return L.divIcon({
+    className: 'station-pin',
+    html: svg,
+    iconSize: [w, h],
+    iconAnchor: [w / 2, h - 2],
+    popupAnchor: [0, -h + 8],
+  });
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,15 @@ html, body { height: 100%; background: #fff; color: #111; }
 /* Map root wrapper so absolute elements (controls/panel) anchor correctly */
 .map-root { position: relative; }
 
+/* mobile full-height helper */
+@supports (height: 100dvh) {
+  .h-100dvh { height: 100dvh; }
+}
+
+/* Touch/scroll polish for Leaflet on mobile */
+.leaflet-container { touch-action: pan-x pan-y; }
+.leaflet-overlay-pane, .leaflet-marker-pane { will-change: transform; } /* smoother on mobile */
+
 /* Ensure the Leaflet map has predictable height; adjust footer/header allowance if needed */
 .leaflet-map {
   height: calc(100vh - 120px);


### PR DESCRIPTION
**Test steps:**
1. Open /model1-heatmap on iOS Safari and Android Chrome
2. Rotate device, scroll up/down
3. Map remains fully visible and interactive
4. No odd gestures or scroll glitches

Includes:
- Real viewport height via CSS var and resize/orientation listeners
- Leaflet invalidateSize on resize/orientation/visibility
- Touch-action and will-change polish for smoother mobile map
